### PR TITLE
Add assert_schema_correct to pytest schema tester plugin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,4 +35,4 @@ pytest11 =
 minversion = 4.6
 
 [flake8]
-max-line-length = 100
+max-line-length = 120

--- a/src/pytest_asdf_schema/common.py
+++ b/src/pytest_asdf_schema/common.py
@@ -140,6 +140,8 @@ def assert_schema_correct(path):
     assert "description" in schema, f"{path.name} is missing description key"
     assert len(schema["description"].strip()) > 0, f"{path.name} description must have content"
 
+    # The following two depend on having a full list of schemas.  Any idea how
+    # to do this?
     # assert len(id_to_schema(schema["id"])) == 1, f"{path.name} does not have a unique id"
 
     # if "tag" in schema:

--- a/src/pytest_asdf_schema/common.py
+++ b/src/pytest_asdf_schema/common.py
@@ -140,7 +140,7 @@ def assert_schema_correct(path):
     assert "description" in schema, f"{path.name} is missing description key"
     assert len(schema["description"].strip()) > 0, f"{path.name} description must have content"
 
-    # The following two depend on having a full list of schemas.  Any idea how
+    # The following two checks depend on having a full list of schemas.  Any idea how
     # to do this?
     # assert len(id_to_schema(schema["id"])) == 1, f"{path.name} does not have a unique id"
 

--- a/src/pytest_asdf_schema/plugin.py
+++ b/src/pytest_asdf_schema/plugin.py
@@ -2,11 +2,14 @@ import io
 import os
 from importlib.util import find_spec
 from pkg_resources import parse_version
+from pathlib import Path
 
 import yaml
 import pytest
 
 import numpy as np
+
+from . import common
 
 # Avoid all imports of asdf at this level in order to avoid circular imports
 
@@ -100,6 +103,7 @@ class AsdfSchemaItem(pytest.Item):
             self.schema_path, resolver=default_extensions.resolver,
             resolve_references=True)
         schema.check_schema(schema_tree)
+        common.assert_schema_correct(Path(self.schema_path))
 
 
 ASTROPY_4_0_TAGS = {


### PR DESCRIPTION
This ports over the pytest assertion helper `assert_schemas_correct` in `asdf-standard`

https://github.com/asdf-format/asdf-standard/blob/29d34109e88a746abad5f9e85857133c39f45321/tests/conftest.py#L112-L155

to the pytest schema tester plugin.

Checks that depend on knowing the location of all the schemas are not implemented.

This was tested on `asdf-transform-schemas`.  All tests pass.